### PR TITLE
Suggest using a more restrictive firewall zone

### DIFF
--- a/README.Fedora
+++ b/README.Fedora
@@ -57,8 +57,15 @@ example, on my system, to get the firewall zone I’m using:
  # firewall-cmd --get-active-zones 
  public
    interfaces: em1
+   
+You may want to set up a home or other trusted zone in your firewall. This will
+help protect your system from unauthorized remote access over the internet.
+This is out of scope for this help text, but
+[this tutorial](https://ctrl.blog/entry/how-to-firewalld-zone-by-ip) will guide
+you through the process.
 
-Then enable it permanently (i.e. at reboot) and immediately with these commands:
+Then enable the Steam service permanently (i.e. at reboot) on the public or
+your preferred zone immediately with these commands:
 
  # firewall-cmd --zone=public --add-service=steam --permanent
  # firewall-cmd --zone=public --add-service=steam


### PR DESCRIPTION
IPv6 is global routeable by default. Should not recommend a globally routeable zone for something meant to be used in a small trusted network.