### PR TITLE
raise file descriptor limits for esync

### DIFF
--- a/01-steam.conf
+++ b/01-steam.conf
@@ -1,0 +1,10 @@
+# A systemd configuration override.
+# This belongs into /usr/lib/systemd/{system,user}.conf.d/
+
+[Manager]
+# Increase the file descriptor limit to make Steam Proton/Wine esync work
+# out of the box. The same limit will be increased by default in systemd 240.
+# More info:
+# https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/ZN5TK3D6L7SE46KGXICUKLKPX2LQISVX/
+# https://github.com/systemd/systemd/pull/10244
+DefaultLimitNOFILE=1024:262144

--- a/steam.spec
+++ b/steam.spec
@@ -3,7 +3,7 @@
 
 Name:           steam
 Version:        1.0.0.56
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file
 License:        Steam License Agreement
@@ -25,8 +25,10 @@ Source4:        %{name}.appdata.xml
 Source8:        https://raw.githubusercontent.com/denilsonsa/udev-joystick-blacklist/master/after_kernel_4_9/51-these-are-not-joysticks-rm.rules
 # First generation Nvidia Shield controller seen as mouse:
 Source9:        https://raw.githubusercontent.com/cyndis/shield-controller-config/master/99-shield-controller.rules
-
 Source10:       README.Fedora
+# Configure limits in systemd
+# This should be only needed with systemd < 240
+Source11:       01-steam.conf
 
 # Remove temporary leftover files after run (fixes multiuser):
 # https://github.com/ValveSoftware/steam-for-linux/issues/3570
@@ -154,6 +156,12 @@ install -pm 644 %{SOURCE1} %{SOURCE2} %{buildroot}%{_sysconfdir}/profile.d
 mkdir -p %{buildroot}%{_datadir}/appdata
 install -p -m 0644 %{SOURCE4} %{buildroot}%{_datadir}/appdata/
 
+# Systemd configuration
+mkdir -p %{buildroot}%{_prefix}/lib/systemd/system.conf.d/
+mkdir -p %{buildroot}%{_prefix}/lib/systemd/user.conf.d/
+install -m 644 -p %{SOURCE11} %{buildroot}%{_prefix}/lib/systemd/system.conf.d/
+install -m 644 -p %{SOURCE11} %{buildroot}%{_prefix}/lib/systemd/user.conf.d/
+
 %post
 %if 0%{?rhel} == 7
 /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
@@ -190,8 +198,15 @@ fi
 %{_prefix}/lib/firewalld/services/%{name}.xml
 %config(noreplace) %{_sysconfdir}/profile.d/%{name}.*sh
 %{_udevrulesdir}/*
+%{_prefix}/lib/systemd/system.conf.d/
+%{_prefix}/lib/systemd/system.conf.d/01-steam.conf
+%{_prefix}/lib/systemd/user.conf.d/
+%{_prefix}/lib/systemd/user.conf.d/01-steam.conf
 
 %changelog
+* Fri Nov 02 2018 Kamil Páral <kamil.paral@gmail.com> - 1.0.0.56-3
+- add systemd configuration for increasing file descriptor limit (for esync)
+
 * Mon Oct 15 2018 Simone Caronni <negativo17@gmail.com> - 1.0.0.56-2
 - Update Vulkan requirements for CentOS/RHEL 7.
 - Update ports list for 11th October 2018 client.


### PR DESCRIPTION
This increases limits of number of opened files by a process. The main
benefactor is Proton/Wine esync which uses a lot of file descriptors in
order to work properly. The limit value is raised from 4K to 256K, which
is in line with a future systemd change (256K will be the default since
systemd 240). See the links in the configuration file for more
information.

----

The purpose of this PR is that users of systems older than Fedora 30 can also benefit from this change and don't need to adjust the limits manually, if they want to use Proton (Steam Play).