### PR TITLE
don't override NOFILE systemd limits on F30+

### DIFF
--- a/01-steam.conf
+++ b/01-steam.conf
@@ -3,8 +3,9 @@
 
 [Manager]
 # Increase the file descriptor limit to make Steam Proton/Wine esync work
-# out of the box. The same limit will be increased by default in systemd 240.
+# out of the box. The same limit is increased by default in systemd 240, and
+# this patch is no longer needed.
 # More info:
 # https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/ZN5TK3D6L7SE46KGXICUKLKPX2LQISVX/
 # https://github.com/systemd/systemd/pull/10244
-DefaultLimitNOFILE=1024:262144
+DefaultLimitNOFILE=1024:524288

--- a/steam.spec
+++ b/steam.spec
@@ -3,7 +3,7 @@
 
 Name:           steam
 Version:        1.0.0.59
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file
 License:        Steam License Agreement
@@ -160,10 +160,13 @@ mkdir -p %{buildroot}%{_datadir}/appdata
 install -p -m 0644 %{SOURCE4} %{buildroot}%{_datadir}/appdata/
 
 # Systemd configuration
+# Since F30 (systemd 240) we don't need to raise NOFILE limit
+%if 0%{?fedora} && 0%{?fedora} < 30
 mkdir -p %{buildroot}%{_prefix}/lib/systemd/system.conf.d/
 mkdir -p %{buildroot}%{_prefix}/lib/systemd/user.conf.d/
 install -m 644 -p %{SOURCE11} %{buildroot}%{_prefix}/lib/systemd/system.conf.d/
 install -m 644 -p %{SOURCE11} %{buildroot}%{_prefix}/lib/systemd/user.conf.d/
+%endif
 
 %post
 %if 0%{?rhel} == 7
@@ -201,12 +204,19 @@ fi
 %{_prefix}/lib/firewalld/services/%{name}.xml
 %config(noreplace) %{_sysconfdir}/profile.d/%{name}.*sh
 %{_udevrulesdir}/*
+
+# Since F30 (systemd 240) we don't need to raise NOFILE limit
+%if 0%{?fedora} && 0%{?fedora} < 30
 %{_prefix}/lib/systemd/system.conf.d/
 %{_prefix}/lib/systemd/system.conf.d/01-steam.conf
 %{_prefix}/lib/systemd/user.conf.d/
 %{_prefix}/lib/systemd/user.conf.d/01-steam.conf
+%endif
 
 %changelog
+* Wed Jan 02 2019 Kamil Páral <kamil.paral@gmail.com> - 1.0.0.59-3
+- NOFILE limit doesn't need to be raised since F30 (systemd 240)
+
 * Thu Dec 20 2018 Nicolas Chauvet <kwizart@gmail.com> - 1.0.0.59-2
 - Drop vulkan on el7 for now
 


### PR DESCRIPTION
The limits have been raised by default, we no longer need to override
them. Also, adjust the limit on <=F29 to the same value systemd devs
used in F30.