### PR TITLE
Updated Steam.spec for RHEL 8

### DIFF
--- a/steam.spec
+++ b/steam.spec
@@ -110,8 +110,8 @@ Requires:       alsa-plugins-pulseaudio%{?_isa}
 
 # Game performance is increased with gamemode (for games that support it)
 %if 0%{?fedora} || 0%{?rhel} >= 8
-Requires:       gamemode
-Requires:       gamemode%{?_isa}
+Recommends:       gamemode
+Recommends:       gamemode%{?_isa}
 # Recommends:     gnome-shell-extension-gamemode
 %endif
 


### PR DESCRIPTION
RHEL 8 does not have Gamemode yet and in EPEL - testing we currently only have 64 bit gamemode.. Steam is unable to download or update because of this as gamemode is put inside requirement It should be recommended as its not necessary. sudo dnf update steam                                                      ─╯
Updating Subscription Management repositories.
Last metadata expiration check: 0:02:37 ago on Mon 04 May 2020 02:54:52 PM IST.
Error: 
 Problem: cannot install the best update candidate for package steam-1.0.0.61-4.el8.i686
  - nothing provides gamemode(x86-32) needed by steam-1.0.0.62-1.el8.i686
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)