### PR TITLE
specfile: use excludeArch rather than exclusiveArch

### DIFF
--- a/steam.spec
+++ b/steam.spec
@@ -10,7 +10,8 @@ Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
 URL:            http://www.steampowered.com/
-ExclusiveArch:  i686
+ExcludeArch:  aarch64
+ExcludeArch:  ppc64le
 
 Source0:        https://repo.steampowered.com/%{name}/archive/beta/%{name}_%{version}.tar.gz
 Source1:        %{name}.sh


### PR DESCRIPTION
This should allow to pull x64 dependencies when they are available.

This came up in the context of creating systemd-sysexts where we install the rpms in an empty directory. Resolving the dependencies for this rpm pulls only i386, which end up overlaying a lot of already existing 64 bits binaries on the system.

[1] https://fedoraproject.org/wiki/Architectures#ExcludeArch_&_ExclusiveArch
[2] https://github.com/travier/fedora-sysexts/tree/main/steam-kinoite